### PR TITLE
:bug: Fix a duplicate path addition

### DIFF
--- a/zsh-exa.plugin.zsh
+++ b/zsh-exa.plugin.zsh
@@ -92,8 +92,12 @@ update_zsh_exa() {
 }
 
 _zsh_exa_load() {
-    # export PATH
-    export PATH=${PATH}:${EXA_HOME}/bin
+    local -r exadir=$EXA_HOME/bin
+
+    # Add the exa bin directory path if it doesn't exist in $PATH.
+    if [[ -z ${path[(r)$exadir]} ]]; then
+        path+=($exadir)
+    fi
 }
 
 # install exa if it isnt already installed


### PR DESCRIPTION
The previous path addition doesn't have a guard statement. It probably spawns value duplicated $PATH such as `PATH=/a/path:~/.exa/bin:~/.exa/bin:~/.exa/bin` when runs nested zsh. So adds a guard statement to check whether or not the exa bin directory path exists in $PATH.

$PATH is exported by default, so no need to re-export explicitly. And $path is a tied variable to $PATH, so we can think as it is exported too.